### PR TITLE
실행 명령과 백엔드 엔트리포인트 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This is a monorepo.
 - Do not proactively inspect or modify global tool configuration just because a matching tool might be useful.
 - In mixed macOS/Windows environments, identify the current device/OS first before checking config paths.
 - Do not guess config locations from memory alone; check the official documentation for the relevant agent/tool first.
+- On Windows, prefer `cmd` over PowerShell for Codex command execution unless PowerShell is specifically required.
 - Default inspection order is: project config first, then user config, then managed/system config only if needed and user-approved.
 - If the user wants the check, then inspect the relevant project config and global config paths.
 - If a required tool or MCP server is missing, explain what needs to be installed or configured before changing global state.

--- a/README.md
+++ b/README.md
@@ -58,36 +58,36 @@
 
 - Python 버전 기준: `3.12`
 - 패키지/의존성 관리: `uv`
-- 실행 예시:
+- 각 워크스페이스 디렉터리 안에서 바로 실행:
 
 ```bash
 cd be
 uv sync
-uv run python -m be
+uv run be
 ```
 
 ```bash
 cd back_research
 uv sync
-uv run python -m back_research
+uv run back-research
 ```
 
 ### Frontend
 
-- 패키지 관리: `npm`
+- 패키지 관리: `bun`
 - 실행 예시:
 
 ```bash
 cd fe
-npm install
-npm run dev
+bun install
+bun dev
 ```
 
 프로덕션 빌드 확인:
 
 ```bash
 cd fe
-npm run build
+bun run build
 ```
 
 ## 검증 방법
@@ -112,7 +112,7 @@ uv run ty check
 
 ```bash
 cd fe
-npm run build
+bun run build
 ```
 
 ## 로컬 IDE 설정 정책

--- a/back_research/README.md
+++ b/back_research/README.md
@@ -6,7 +6,9 @@ Python research workspace managed with `uv`.
 
 ```bash
 uv sync
-uv run python -m back_research
+uv run back-research
 uv run pytest
 uv run ty check
 ```
+
+현재 디렉터리가 `back_research/` 라면 위 명령만으로 바로 실행할 수 있다.

--- a/be/README.md
+++ b/be/README.md
@@ -39,11 +39,13 @@ be/
 
 ```bash
 uv sync
-uv run uvicorn be.app:app --reload
+uv run be
 uv run pytest
 uv run ruff check
 uv run ty check
 ```
+
+현재 디렉터리가 `be/` 라면 `uv run be` 로 개발 서버를 바로 띄울 수 있다.
 
 ## API Surface
 
@@ -67,7 +69,7 @@ uv run ty check
 
 Use one FastAPI service first.
 
-- Local/dev: `uv run uvicorn be.app:app --reload`
+- Local/dev: `uv run be`
 - Container/prod: Uvicorn workers behind your normal ingress/reverse proxy
 - Keep prediction in the same process until one of these becomes true:
   - model artifact is large

--- a/be/src/be/__init__.py
+++ b/be/src/be/__init__.py
@@ -1,8 +1,10 @@
+import uvicorn
+
 from be.app import app
 
 
 def main() -> None:
-    print("Run with: uv run uvicorn be.app:app --reload")
+    uvicorn.run("be.app:app", host="127.0.0.1", port=8000, reload=True)
 
 
 __all__ = ["app", "main"]

--- a/be/tests/test_smoke.py
+++ b/be/tests/test_smoke.py
@@ -6,17 +6,30 @@ from be import app, main
 client = TestClient(app)
 
 
-def test_main_runs(capsys) -> None:
+def test_main_runs(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def fake_run(app_path: str, *, host: str, port: int, reload: bool) -> None:
+        called["app_path"] = app_path
+        called["host"] = host
+        called["port"] = port
+        called["reload"] = reload
+
+    monkeypatch.setattr("be.uvicorn.run", fake_run)
     main()
-    captured = capsys.readouterr()
-    assert "uvicorn be.app:app --reload" in captured.out
+    assert called == {
+        "app_path": "be.app:app",
+        "host": "127.0.0.1",
+        "port": 8000,
+        "reload": True,
+    }
 
 
 def test_architecture_endpoint_exposes_repo_context() -> None:
     response = client.get("/api/system/architecture")
     assert response.status_code == 200
     body = response.json()
-    assert body["repo_root"].endswith("SKN28-2nd-4team")
+    assert body["repo_root"].lower().endswith("skn28-2nd-4team")
     assert body["scenario_dir"].endswith("scenarios")
 
 

--- a/fe/README.md
+++ b/fe/README.md
@@ -6,13 +6,15 @@ This frontend uses `Bun` as the package manager and script runner.
 
 ```bash
 bun install
-bun run dev
+bun dev
 ```
 
 ```bash
 bun run build
 bun run lint
 ```
+
+빠르게 확인할 때는 `bun install` 후 `bun dev` 로 바로 실행하면 된다.
 
 ## Current demo scope
 


### PR DESCRIPTION
## 변경 내용
- backend 실행 엔트리포인트를 `uv run be` 기준으로 정리
- smoke 테스트를 엔트리포인트 동작에 맞게 보정
- 루트/워크스페이스 README의 실행 명령을 현재 방식에 맞게 업데이트
- Windows Codex 작업 시 `cmd` 우선 사용 규칙을 AGENTS에 반영

## 검증
- `be/.venv/Scripts/python -m pytest tests/test_smoke.py`